### PR TITLE
[FE][관리자 페이지] MobileNav 온/오프 시 z-index 계산으로 인한 딤드 지연현상 수정 (#518)

### DIFF
--- a/frontend/manage/src/components/atoms/Modal/index.tsx
+++ b/frontend/manage/src/components/atoms/Modal/index.tsx
@@ -5,10 +5,11 @@ export interface Props {
   isOpen: boolean;
   children: ReactNode;
   dimmedOpacity?: number;
+  blockScroll?: boolean;
   closeModal: () => void;
 }
 
-const Modal = ({ isOpen, closeModal, children, dimmedOpacity = 0.6 }: Props) => {
+const Modal = ({ isOpen, closeModal, children, dimmedOpacity = 0.6, blockScroll = true }: Props) => {
   const dimmedRef = useRef(null);
   const onCloseModal = (event: MouseEvent) => {
     if (event.target !== dimmedRef.current) return;
@@ -17,13 +18,13 @@ const Modal = ({ isOpen, closeModal, children, dimmedOpacity = 0.6 }: Props) => 
   };
 
   useEffect(() => {
-    document.body.style.setProperty("overflow", isOpen ? "hidden" : "revert");
+    if (blockScroll) document.body.style.setProperty("overflow", isOpen ? "hidden" : "revert");
   }, [isOpen]);
 
   return (
     <>
       <Dimmed ref={dimmedRef} onClick={onCloseModal} isOpen={isOpen} opacity={dimmedOpacity} />
-      {isOpen && children}
+      {children}
     </>
   );
 };

--- a/frontend/manage/src/components/organisms/CommentSearchConditionForm/index.tsx
+++ b/frontend/manage/src/components/organisms/CommentSearchConditionForm/index.tsx
@@ -52,8 +52,9 @@ const CommentSearchConditionForm = ({
             <DateInputText onClick={() => setShowCalendar(true)}>{endDate?.format("YY-MM-DD")}</DateInputText>
           </DateRange>
 
-          <Modal isOpen={showCalendar} closeModal={() => setShowCalendar(false)} dimmedOpacity={0}>
+          <Modal isOpen={showCalendar} blockScroll={false} closeModal={() => setShowCalendar(false)} dimmedOpacity={0}>
             <Calendar
+              isOpen={showCalendar}
               date={currentDate}
               setDate={setCurrentDate}
               startDate={startDate}

--- a/frontend/manage/src/components/organisms/CommentSearchConditionForm/styles.ts
+++ b/frontend/manage/src/components/organisms/CommentSearchConditionForm/styles.ts
@@ -63,9 +63,9 @@ export const DateRange = styled.span`
   margin-left: 1rem;
 `;
 
-export const Calendar = styled(CalendarComponent)`
+export const Calendar = styled(CalendarComponent)<{ isOpen: boolean }>`
   position: absolute;
   top: 5rem;
   left: 6.5rem;
-  z-index: ${Z_INDEX.MODAL + 1};
+  z-index: ${({ isOpen }) => (isOpen ? Z_INDEX.MODAL + 1 : -1)};
 `;

--- a/frontend/manage/src/components/organisms/MobileNav/index.tsx
+++ b/frontend/manage/src/components/organisms/MobileNav/index.tsx
@@ -4,10 +4,9 @@ import { ROUTE } from "../../../constants";
 import { useUser } from "../../../hooks";
 import { PALETTE } from "../../../styles/palette";
 import { MenuType } from "../../../types/menu";
-import { User } from "../../../types/user";
 import HamburgerButton from "../../atoms/Buttons/HamburgerButton";
 import Modal from "../../atoms/Modal";
-import { Container, Menu, MenuAvatar, MenuWrapper, Name, AuthLink } from "./styles";
+import { AuthLink, Container, Menu, MenuAvatar, MenuWrapper, Name } from "./styles";
 
 export interface Props {
   menuList: MenuType[];

--- a/frontend/manage/src/components/organisms/MobileNav/styles.ts
+++ b/frontend/manage/src/components/organisms/MobileNav/styles.ts
@@ -27,7 +27,7 @@ export const MenuWrapper = styled.nav<{ isOpen: boolean }>`
   top: 0;
   left: 0;
   transform: ${({ isOpen }) => (isOpen ? "translateX(0)" : "translateX(-100%)")};
-  transition: transform 0.3s ease-in-out;
+  transition: transform 0.4s ease-in-out;
 `;
 
 export const Name = styled.p`

--- a/frontend/manage/src/components/pages/Statistics/index.tsx
+++ b/frontend/manage/src/components/pages/Statistics/index.tsx
@@ -98,8 +98,14 @@ const Statistics = () => {
                   <DateInputText onClick={onClickDateInput}>{endDate?.format("YY-MM-DD")}</DateInputText>
                 </DateRange>
 
-                <Modal isOpen={showCalendar} closeModal={() => setShowCalendar(false)} dimmedOpacity={0}>
+                <Modal
+                  isOpen={showCalendar}
+                  blockScroll={false}
+                  closeModal={() => setShowCalendar(false)}
+                  dimmedOpacity={0}
+                >
                   <Calendar
+                    isOpen={showCalendar}
                     date={currentDate}
                     setDate={setCurrentDate}
                     startDate={startDate}

--- a/frontend/manage/src/components/pages/Statistics/styles.ts
+++ b/frontend/manage/src/components/pages/Statistics/styles.ts
@@ -26,11 +26,11 @@ export const Wrapper = styled.div`
   margin-bottom: 1rem;
 `;
 
-export const Calendar = styled(CalendarComponent)`
+export const Calendar = styled(CalendarComponent)<{ isOpen: boolean }>`
   position: absolute;
   top: 4rem;
   left: 5.5rem;
-  z-index: ${Z_INDEX.MODAL + 1};
+  z-index: ${({ isOpen }) => (isOpen ? Z_INDEX.MODAL + 1 : -1)};
 `;
 
 export const Meta = styled.span`

--- a/frontend/manage/src/styles/constants.ts
+++ b/frontend/manage/src/styles/constants.ts
@@ -5,14 +5,14 @@ export const Z_INDEX = {
   ERROR_NOTICE: 1,
   NAV: {
     MOBILE: {
-      HAMBUGER_BUTTON: 2,
-      MENU_WRAPPER: 1
+      HAMBUGER_BUTTON: 200,
+      MENU_WRAPPER: 199
     },
     DESKTOP: {
       USER_AVATAR_WRAPPER: 1
     }
   },
-  MODAL: 1
+  MODAL: 100
 } as const;
 
 export const LINE_HEIGHT_SCALE = 1.5;


### PR DESCRIPTION
![딤드지연](https://user-images.githubusercontent.com/42544600/131089507-0a5c71a2-3bc7-48b2-8b48-ab2726e2735d.gif)


- 버그가 있는 z-index 부분 차이를 100으로 둬서, 딤드 지연현상 해결
- 사이드바 transition 안되고 있던 부분, 되도록 수정
- Modal이 무조건 body의 scroll을 block하고 있었는데, 달력을 킬때마다 스크롤이 나타났다 없어져서 화면이 흔들려가지고, scroll을 막고 허용하는 인자를 추가하여, 달력 모달에서는 스크롤 허용