### PR TITLE
[FE][공통] access token , refresh token 만료가 되기 전에 재발급 받도록 한다.

### DIFF
--- a/frontend/manage/src/constants/timer.ts
+++ b/frontend/manage/src/constants/timer.ts
@@ -3,7 +3,7 @@ import { BUILD_MODE_TABLE } from "../types/buildMode";
 const TOKEN_REFETCH_TIMER_TABLE = {
   localhost: 25 * 1000,
   development: 25 * 1000,
-  production: 55 * 60 * 1000
+  production: 25 * 1000
 } as const;
 
 export const TOKEN_REFETCH_TIMER = TOKEN_REFETCH_TIMER_TABLE[process.env.BUILD_MODE as keyof BUILD_MODE_TABLE];

--- a/frontend/reply-module/src/constants/timer.ts
+++ b/frontend/reply-module/src/constants/timer.ts
@@ -3,7 +3,7 @@ import { BUILD_MODE_TABLE } from "../types/buildMode";
 const TOKEN_REFETCH_TIMER_TABLE = {
   localhost: 25 * 1000,
   development: 25 * 1000,
-  production: 55 * 60 * 1000
+  production: 25 * 1000
 } as const;
 
 export const TOKEN_REFETCH_TIMER = TOKEN_REFETCH_TIMER_TABLE[process.env.BUILD_MODE as keyof BUILD_MODE_TABLE];


### PR DESCRIPTION
기존에 access token 만료가 30초이므로, 30초 이내에서 재요청을 하여 로그아웃 되지 않도록 하였습니다.