### PR TITLE
[BE] health Check하는 nginx 제거하고, Spring에 health check API 만들기

### DIFF
--- a/backend/src/main/java/com/darass/healthcheck/controller/HealthCheckController.java
+++ b/backend/src/main/java/com/darass/healthcheck/controller/HealthCheckController.java
@@ -1,0 +1,15 @@
+package com.darass.healthcheck.controller;
+
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HealthCheckController {
+    @GetMapping("/health")
+    public ResponseEntity<Void> healthCheck() {
+        return ResponseEntity.status(HttpStatus.OK).body(null);
+    }
+}

--- a/backend/src/test/java/com/darass/healthcheck/controller/HealthCheckControllerTest.java
+++ b/backend/src/test/java/com/darass/healthcheck/controller/HealthCheckControllerTest.java
@@ -1,0 +1,19 @@
+package com.darass.healthcheck.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.darass.darass.AcceptanceTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("HealthCheckController 클래스")
+public class HealthCheckControllerTest extends AcceptanceTest {
+
+    @DisplayName("/health GET으로 요청했을 때, 200으로 응답")
+    @Test
+    public void healthCheckTest() throws Exception {
+        mockMvc.perform(get("/health"))
+            .andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
Nginx를 통해 /health GET을 통해 Health Check를 했었는데, 
Nginx를 통해 HeatlhCheck를 하게 되면 서버에 장애가 생겼을 때 Health Check를 제대로 하지 못하게 됩니다.
이 때문에, WAS 서버 로직 내에 /health GET에 대한 응답을 할 수 있도록 API를 추가하였습니다. 
close #687