### PR TITLE
[FE][댓글모듈] 유저가 다시 fetch될때 댓글리스트가 다시 렌더링되어 작성중이던 대댓글이 사라지는 이슈 수정

### DIFF
--- a/frontend/reply-module/src/hooks/api/useQuery.ts
+++ b/frontend/reply-module/src/hooks/api/useQuery.ts
@@ -5,9 +5,10 @@ interface Props {
   query: (props?: any) => Promise<any>;
   onSuccess?: () => void;
   refetchInterval?: number;
+  isEqualToPrevDataFunc?: (prev: any, curr: any) => boolean;
 }
 
-export const useQuery = <T>({ enabled, query, onSuccess, refetchInterval }: Props) => {
+export const useQuery = <T>({ enabled, query, onSuccess, refetchInterval, isEqualToPrevDataFunc }: Props) => {
   const [isLoading, setIsLoading] = useState(false);
   const [isError, setIsError] = useState(false);
   const [isFetched, setIsFetched] = useState(false);
@@ -22,7 +23,14 @@ export const useQuery = <T>({ enabled, query, onSuccess, refetchInterval }: Prop
 
       const newData = await query();
 
-      setData(newData);
+      if (isEqualToPrevDataFunc) {
+        if (!isEqualToPrevDataFunc(data, newData)) {
+          setData(newData);
+        }
+      } else {
+        setData(newData);
+      }
+
       await onSuccess?.();
       setIsFetched(true);
     } catch (error) {

--- a/frontend/reply-module/src/hooks/api/user/useUser.ts
+++ b/frontend/reply-module/src/hooks/api/user/useUser.ts
@@ -38,6 +38,10 @@ export const useUser = () => {
     clearRefetchInterval
   } = useGetAccessTokenApi();
 
+  const compareUser = (prevUser?: User, currUser?: User) => {
+    return prevUser?.id === currUser?.id;
+  };
+
   const {
     data: user,
     isLoading,
@@ -47,7 +51,8 @@ export const useUser = () => {
     setData: setUser
   } = useQuery<User>({
     query: getUser,
-    enabled: false
+    enabled: false,
+    isEqualToPrevDataFunc: compareUser
   });
 
   const { mutation: deleteMutation } = useMutation<void, void>({


### PR DESCRIPTION
커스텀 react-query에 받아온 데이터를 비교하는 콜백을 넘겨주어, User를 fetch했을때 같은 User이면
전체적인 re-rendering이 안일어나도록 했습니다.