### PR TITLE
[BE] 대댓글이 삭제되지 않는 버그를 해결한다.

### DIFF
--- a/backend/src/main/java/com/darass/comment/domain/Comment.java
+++ b/backend/src/main/java/com/darass/comment/domain/Comment.java
@@ -130,12 +130,20 @@ public class Comment extends BaseTimeEntity {
         this.commentLikes.remove(commentLike);
     }
 
+    public void deleteSubComment(Long id) {
+        subComments.removeIf(subComment -> subComment.isSameId(id));
+    }
+
     public void addCommentLike(CommentLike commentLike) {
         this.commentLikes.add(commentLike);
     }
 
     public boolean isSubComment() {
         return !Objects.isNull(this.parent);
+    }
+
+    public boolean isSameId(Long id) {
+        return this.id.equals(id);
     }
 
     public int getSubCommentSize() {

--- a/backend/src/main/java/com/darass/comment/service/CommentService.java
+++ b/backend/src/main/java/com/darass/comment/service/CommentService.java
@@ -161,6 +161,10 @@ public class CommentService {
         validateCommentDeletableByUser(user, adminUser, comment);
 
         commentRepository.deleteById(id);
+        if (comment.isSubComment()) {
+            Comment parent = comment.getParent();
+            parent.deleteSubComment(id);
+        }
     }
 
     public void toggleLike(Long id, User user) {


### PR DESCRIPTION
- 인수 테스트 및 로컬에서는 대댓글이 잘 지워진다.
- 수동으로 부모 댓글에서 자식 댓글을 지워주는 작업을 거쳤는데, 개발 서버에서 잘 동작하는지 확인이 필요하다.