### PR TITLE
[FE][관리자페이지] 관리자 페이지에서 알림버튼 눌렀을때 빨간 점 안없어지는 이슈 수정

### DIFF
--- a/frontend/manage/src/components/organisms/Nav/DesktopNav/index.tsx
+++ b/frontend/manage/src/components/organisms/Nav/DesktopNav/index.tsx
@@ -50,6 +50,7 @@ const DesktopNav = ({ menuList }: Props) => {
       await editUser(formData);
 
       setHasNewAlarmOnRealTime?.(false);
+      refetchUser();
     } catch (error) {
       if (error instanceof AlertError) {
         alert(error.message);


### PR DESCRIPTION
알림 아이콘 눌렀을때, 새로운 알람이 있는지에 대한 필드를 editUser로 patch한 다음에 유저를 refetch 해오지 않고 있던 이슈 해결